### PR TITLE
Deprecated: Optional parameter $field_escaped_value declared before r…

### DIFF
--- a/cmb-field-select2.php
+++ b/cmb-field-select2.php
@@ -66,7 +66,7 @@ class PW_CMB2_Field_Select2 {
 			'name'             => $field_type_object->_name() . '[]',
 			'id'               => $field_type_object->_id(),
 			'desc'             => $field_type_object->_desc( true ),
-			'options'          => $this->get_pw_multiselect_options( $field_escaped_value, $field_type_object ),
+			'options'          => $this->get_pw_multiselect_options( $field_type_object, $field_escaped_value),
 			'data-placeholder' => $field->args( 'attributes', 'placeholder' ) ? $field->args( 'attributes', 'placeholder' ) : $field->args( 'description' ),
 		) );
 
@@ -80,7 +80,7 @@ class PW_CMB2_Field_Select2 {
 	 * Return the list of options, with selected options at the top preserving their order. This also handles the
 	 * removal of selected options which no longer exist in the options array.
 	 */
-	public function get_pw_multiselect_options( $field_escaped_value = array(), $field_type_object ) {
+	public function get_pw_multiselect_options( $field_type_object, $field_escaped_value = array() ) {
 		$options = (array) $field_type_object->field->options();
 
 		// If we have selected items, we need to preserve their order


### PR DESCRIPTION
…equired parameter $field_type_object is implicitly treated as a required parameter in line 83

When declaring a function or a method, adding a required parameter after optional parameters is deprecated since PHP 8.0. public function get_pw_multiselect_options( $field_type_object, $field_escaped_value = array() ) { Swap parameters of the above function and also in the call function  in line 69
'options'          => $this->get_pw_multiselect_options( $field_type_object, $field_escaped_value),